### PR TITLE
avoid user confusion

### DIFF
--- a/progen2/likelihood.py
+++ b/progen2/likelihood.py
@@ -119,13 +119,13 @@ def main():
     # (1) params
 
     parser = argparse.ArgumentParser()
-    parser.add_argument('--model', type=str, choices=models, default='progen2-large')
+    parser.add_argument('--model', type=str, choices=models, default='progen2-base')
     parser.add_argument('--device', type=str, default='cuda:0')
     parser.add_argument('--rng-seed', type=int, default=42)
     parser.add_argument('--rng-deterministic', default=True, type=lambda x: (str(x).lower() == 'true'))
     parser.add_argument('--fp16', default=True, type=lambda x: (str(x).lower() == 'true'))
     parser.add_argument('--context', type=str, default='1MGHGVSRPPVVTLRPAVLDDCPVLWRWRNDPETRQASVDEREIPVDTHTRWFEETLKRFDRKLFIVSADGVDAGMVRLDIQDRDAAVSVNIAPEWRGRGVGPRALGCLSREAFGPLALLRMSAVVKRENAASRIAFERAGFTVVDTGGPLLHSSKARLHVVAAIQARMGSTRLPGKVLVSIAGRPTIQRIAERLAVCQELDAVAVSTSVENRDDAIADLAAHLGLVCVRGSETDLIERLGRTAARTGADALVRITADCPLVDPALVDRVVGVWRRSAGRLEYVSNVFPPTFPDGLDVEVLSRTVLERLDREVSDPFFRESLTAYVREHPAAFEIANVEHPEDLSRLRWTMDYPEDLAFVEAVYRRLGNQGEIFGMDDLLRLLEWSPELRDLNRCREDVTVERGIRGTGYHAALRARGQAP2')
-    parser.add_argument('--sanity', default=True, type=lambda x: (str(x).lower() == 'true'))
+    parser.add_argument('--sanity', default=False, type=lambda x: (str(x).lower() == 'true'))
     args = parser.parse_args()
 
 
@@ -268,7 +268,7 @@ def main():
             assert ll_x_data > ll_x_random
             assert ll_x_data > ll_x_perturb
 
-
+    '''
     # (6) likelihood
 
     with print_time('log-likelihood (left-to-right)'):
@@ -278,7 +278,7 @@ def main():
 
         print(f'll_sum={ll_sum}')
         print(f'll_mean={ll_mean}')
-
+    '''
 
     # (7) likelihood
 


### PR DESCRIPTION
suppress sanity checks and one-sided LL calcs
also change default model to best performing zero-shot model `progen2-base`