### PR TITLE
fix bugs to enable key_value cache for generation

### DIFF
--- a/progen2/models/progen/modeling_progen.py
+++ b/progen2/models/progen/modeling_progen.py
@@ -575,10 +575,10 @@ class ProGenForCausalLM(ProGenPreTrainedModel):
     def set_output_embeddings(self, new_embeddings):
         return
 
-    def prepare_inputs_for_generation(self, input_ids, past=None, **kwargs):
+    def prepare_inputs_for_generation(self, input_ids, past_key_values=None, **kwargs):
         token_type_ids = kwargs.get("token_type_ids", None)
-        # only last token for inputs_ids if past is defined in kwargs
-        if past:
+        # only last token for inputs_ids if past_key_values is defined in kwargs
+        if past_key_values:
             input_ids = input_ids[:, -1].unsqueeze(-1)
             if token_type_ids is not None:
                 token_type_ids = token_type_ids[:, -1].unsqueeze(-1)
@@ -590,13 +590,13 @@ class ProGenForCausalLM(ProGenPreTrainedModel):
             # create position_ids on the fly for batch generation
             position_ids = attention_mask.long().cumsum(-1) - 1
             position_ids.masked_fill_(attention_mask == 0, 1)
-            if past:
+            if past_key_values:
                 position_ids = position_ids[:, -1].unsqueeze(-1)
         else:
             position_ids = None
         return {
             "input_ids": input_ids,
-            "past_key_values": past,
+            "past_key_values": past_key_values,
             "use_cache": kwargs.get("use_cache"),
             "position_ids": position_ids,
             "attention_mask": attention_mask,


### PR DESCRIPTION
The `prepare_inputs_for_generation()` method is used at each decoding step for auto-regressive generation. The default name for the keyword argument of key-value caches is `past_key_values` instead of `past`. Renaming `past` to `past_key_values` fits the Huggingface Transformer interface and enables the key-value cache for the generation.

Please refer to [https://github.com/huggingface/transformers/blob/main/src/transformers/generation/utils.py#L751](https://github.com/huggingface/transformers/blob/main/src/transformers/generation/utils.py#L751).